### PR TITLE
Fix onShortPress not invoked because of long press state

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -71,6 +71,9 @@ var LongPressable = function (_React$PureComponent) {
         }
       }
 
+      // re-initialize long press
+      _this.isLongPressing = false;
+
       _this.startingPosition = eventToPosition(e);
 
       _this.timerID = setTimeout(function () {

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,9 @@ export default class LongPressable extends React.PureComponent {
       }
     }
 
+    // re-initialize long press
+    this.isLongPressing = false;
+    
     this.startingPosition = eventToPosition(e)
 
     this.timerID = setTimeout(() => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -110,4 +110,20 @@ describe('<LongPressable />', () => {
     expect(onLongPress).toHaveBeenCalledTimes(0)
   } )
 
+  it('fires onShortPress when onLongPress previously invoked without onPointerUp invokation', async() => {
+    const { onLongPress, onShortPress, longPressTime } = getDefaultProps()
+    const defaultEvent = {
+      clientX: 0,
+      clientY: 0
+    }
+
+    const wrapper = renderLongPressable(onShortPress, onLongPress, longPressTime)
+    wrapper.instance().onPointerDown(defaultEvent)
+    await timeout(longPressTime + 1)
+    wrapper.instance().onPointerDown(defaultEvent)
+    wrapper.instance().onPointerUp(defaultEvent)
+    expect(onShortPress).toHaveBeenCalledTimes(1)
+    expect(onLongPress).toHaveBeenCalledTimes(1)
+  } )
+
 } )


### PR DESCRIPTION
When long press callback has been invoked by the setTimeout function, the state does not change because it is assuming to be called in the onPointerUp callback, but this isn't guaranteed.

This fix just re-init the state within the onPointerDown event.